### PR TITLE
Update shade_exceptions

### DIFF
--- a/shade/_utils.py
+++ b/shade/_utils.py
@@ -536,6 +536,8 @@ def shade_exceptions(error_message=None):
     except Exception as e:
         if error_message is None:
             error_message = str(e)
+        else:
+            error_message = "%s: %s" % (error_message, e)
         raise exc.OpenStackCloudException(error_message)
 
 


### PR DESCRIPTION
Preserves the inner error message by appending it to the outer error message, as it is documented to do.